### PR TITLE
Improve PHPUnit setting and fixtures

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,11 @@
-<phpunit bootstrap="tests/bootstrap.php">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
     <testsuite name="tests">
         <directory suffix="Test.php">tests</directory>
     </testsuite>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/tests/InheritanceTest.php
+++ b/tests/InheritanceTest.php
@@ -14,7 +14,7 @@ class InheritanceTest extends TestCase
     private $intruder;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->class = new ChildClass();
         $this->intruder = new Intruder($this->class);

--- a/tests/IntruderTest.php
+++ b/tests/IntruderTest.php
@@ -14,7 +14,7 @@ class IntruderTest extends TestCase
     private $intruder;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->class = new AnonymousClass();
         $this->intruder = new Intruder($this->class);


### PR DESCRIPTION
# Changed log

- Using the `phpunit --migrate-configuration` to resolve following warning message:

```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/9.5/fixtures.html#more-setup-than-teardown), it should be the `protected function setUp` and `protected function tearDown` methods.